### PR TITLE
[IT-3964] Create an AMI for agora

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -3,12 +3,23 @@
   become: true
 
   tasks:
+    - name: Add repositories
+      ansible.builtin.yum_repository:
+        name: mongodb
+        description: MongoDB repo
+        baseurl: https://repo.mongodb.org/yum/amazon/2023/mongodb-org/8.0/x86_64/
+        gpgcheck: true
+        gpgkey: https://pgp.mongodb.com/server-8.0.asc
+
     - name: Install packages
-      ansible.builtin.apt:
+      ansible.builtin.dnf:
         state: present
         update_cache: true
         pkg:
-          - "python3-pip"
+          - python
+          - python-pip
+          - mongodb-mongosh-shared-openssl3
+          - mongodb-database-tools
 
     - name: Install python packages
       ansible.builtin.pip:

--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -3,13 +3,20 @@
   become: true
 
   tasks:
-    - name: Add repositories
+    - name: Add Mongo DB repository
       ansible.builtin.yum_repository:
         name: mongodb
         description: MongoDB repo
         baseurl: https://repo.mongodb.org/yum/amazon/2023/mongodb-org/8.0/x86_64/
         gpgcheck: true
         gpgkey: https://pgp.mongodb.com/server-8.0.asc
+
+    - name: Add Microsoft repository
+      ansible.builtin.yum_repository:
+        name: microsoft
+        description: Microsoft repo
+        baseurl: https://packages.microsoft.com/config/centos/8/packages-microsoft-prod
+        gpgcheck: true
 
     - name: Install packages
       ansible.builtin.dnf:
@@ -20,6 +27,7 @@
           - python-pip
           - mongodb-mongosh-shared-openssl3
           - mongodb-database-tools
+          - dotnet-sdk-8.0
 
     - name: Install python packages
       ansible.builtin.pip:

--- a/src/template.json
+++ b/src/template.json
@@ -13,7 +13,7 @@
       "launch_block_device_mappings": [
         {
           "delete_on_termination": true,
-          "device_name": "/dev/sda1",
+          "device_name": "/dev/xvda",
           "volume_size": "{{user `VolumeSize`}}",
           "volume_type": "gp3"
         }
@@ -69,11 +69,11 @@
   "variables": {
     "AmiGroups": "all",
     "EncryptBoot": "false",
-    "InstanceType": "t3.nano",
+    "InstanceType": "t3.micro",
     "OwnerEmail": "it@sagebase.org",
     "SnapshotGroups": "all",
     "SshUsername": "ec2-user",
-    "VolumeSize": "16",
+    "VolumeSize": "64",
     "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
     "aws_profile": "{{env `AWS_PROFILE`}}",
     "aws_region": "{{env `AWS_DEFAULT_REGION`}}",

--- a/src/template.json
+++ b/src/template.json
@@ -20,7 +20,6 @@
       ],
       "profile": "{{user `aws_profile`}}",
       "region": "{{user `aws_region`}}",
-      "temporary_key_pair_type": "ed25519",
       "secret_key": "{{user `aws_secret_key`}}",
       "shutdown_behavior": "terminate",
       "snapshot_groups": "{{user `SnapshotGroups`}}",
@@ -43,6 +42,7 @@
         "SourceAmiId": "{{ .SourceAMI }}",
         "SourceAmiName": "{{ .SourceAMIName }}"
       },
+      "temporary_key_pair_type": "ed25519",
       "token": "{{user `aws_session_token`}}",
       "type": "amazon-ebs"
     }

--- a/src/template.json
+++ b/src/template.json
@@ -25,13 +25,13 @@
       "snapshot_groups": "{{user `SnapshotGroups`}}",
       "source_ami_filter": {
         "filters": {
-          "name": "ubuntu/images/*ubuntu-jammy-22.04-amd64-server-*",
+          "name": "al2023-ami-*-kernel-*-x86_64",
           "root-device-type": "ebs",
           "virtualization-type": "hvm"
         },
         "most_recent": true,
         "owners": [
-          "099720109477"
+          "137112412989"
         ]
       },
       "ssh_username": "{{user `SshUsername`}}",
@@ -72,7 +72,7 @@
     "InstanceType": "t3.nano",
     "OwnerEmail": "it@sagebase.org",
     "SnapshotGroups": "all",
-    "SshUsername": "ubuntu",
+    "SshUsername": "ec2-user",
     "VolumeSize": "16",
     "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
     "aws_profile": "{{env `AWS_PROFILE`}}",

--- a/src/template.json
+++ b/src/template.json
@@ -20,6 +20,7 @@
       ],
       "profile": "{{user `aws_profile`}}",
       "region": "{{user `aws_region`}}",
+      "temporary_key_pair_type": "ed25519",
       "secret_key": "{{user `aws_secret_key`}}",
       "shutdown_behavior": "terminate",
       "snapshot_groups": "{{user `SnapshotGroups`}}",


### PR DESCRIPTION
Create an AMI for the agora bastian with AWS linux x86
instance with mongodb tools and synapse client.

Note: image creation using packer does not fully work,
it fails to connect using the AWS SSM session manager.

![image](https://github.com/user-attachments/assets/5ecb3dbe-f71b-4dc1-87ef-00e74d3c65e4)
 